### PR TITLE
Add curved sound node growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SoundTree
-Experimental Organic Audio 
+Experimental Organic Audio
+
+Start the drone and grow nodes from the central knob to shape a curved soundscape. Each node introduces a new oscillator tuned to a pentatonic scale so the result remains musical.

--- a/script.js
+++ b/script.js
@@ -11,11 +11,21 @@ window.addEventListener('resize', () => {
 let audioCtx;
 let masterGain;
 
+function getMusicalFrequency() {
+    // minor pentatonic around A3/A4
+    const base = 220;
+    const scale = [0, 3, 5, 7, 10];
+    const octave = Math.random() > 0.5 ? 0 : 1;
+    const step = scale[Math.floor(Math.random() * scale.length)];
+    return base * Math.pow(2, octave) * Math.pow(2, step / 12);
+}
+
 class Node {
-    constructor(x, y) {
+    constructor(x, y, opts = {}) {
         this.x = x;
         this.y = y;
-        this.children = [];
+        this.radius = opts.radius || 8;
+        this.children = []; // { node, cp }
         this.osc = null;
         this.gainNode = null;
         if (audioCtx) this.createOscillator();
@@ -24,7 +34,7 @@ class Node {
     createOscillator() {
         this.osc = audioCtx.createOscillator();
         this.gainNode = audioCtx.createGain();
-        const freq = 110 + Math.random() * 220;
+        const freq = getMusicalFrequency();
         this.osc.frequency.setValueAtTime(freq, audioCtx.currentTime);
         this.osc.type = 'sine';
         this.gainNode.gain.setValueAtTime(0.05, audioCtx.currentTime);
@@ -37,6 +47,16 @@ const nodes = [];
 let dragNode = null;
 let dragging = false;
 
+function computeControlPoint(startNode, endPos) {
+    const dx = endPos.x - startNode.x;
+    const dy = endPos.y - startNode.y;
+    const offset = 0.3;
+    return {
+        x: startNode.x + dx / 2 - dy * offset,
+        y: startNode.y + dy / 2 + dx * offset
+    };
+}
+
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.strokeStyle = '#88ff88';
@@ -44,18 +64,26 @@ function draw() {
     ctx.fillStyle = '#ffffff';
 
     for (const n of nodes) {
-        for (const child of n.children) {
+        for (const edge of n.children) {
             ctx.beginPath();
             ctx.moveTo(n.x, n.y);
-            ctx.lineTo(child.x, child.y);
+            const cp = edge.cp || { x: (n.x + edge.node.x) / 2, y: (n.y + edge.node.y) / 2 };
+            ctx.quadraticCurveTo(cp.x, cp.y, edge.node.x, edge.node.y);
             ctx.stroke();
         }
     }
 
     for (const n of nodes) {
         ctx.beginPath();
-        ctx.arc(n.x, n.y, 8, 0, Math.PI * 2);
+        ctx.arc(n.x, n.y, n.radius, 0, Math.PI * 2);
         ctx.fill();
+    }
+
+    if (dragging && dragNode && dragNode.temp) {
+        ctx.beginPath();
+        ctx.moveTo(dragNode.x, dragNode.y);
+        ctx.quadraticCurveTo(dragNode.temp.cp.x, dragNode.temp.cp.y, dragNode.temp.x, dragNode.temp.y);
+        ctx.stroke();
     }
 
     requestAnimationFrame(draw);
@@ -64,7 +92,7 @@ function draw() {
 draw();
 
 function findNode(x, y) {
-    return nodes.find(n => Math.hypot(n.x - x, n.y - y) < 10);
+    return nodes.find(n => Math.hypot(n.x - x, n.y - y) < n.radius + 2);
 }
 
 canvas.addEventListener('mousedown', (e) => {
@@ -83,12 +111,8 @@ canvas.addEventListener('mousemove', (e) => {
         const rect = canvas.getBoundingClientRect();
         const x = e.clientX - rect.left;
         const y = e.clientY - rect.top;
-        if (!dragNode.temp) {
-            dragNode.temp = { x: x, y: y };
-        } else {
-            dragNode.temp.x = x;
-            dragNode.temp.y = y;
-        }
+        const cp = computeControlPoint(dragNode, { x, y });
+        dragNode.temp = { x, y, cp };
     }
 });
 
@@ -97,9 +121,10 @@ canvas.addEventListener('mouseup', (e) => {
         const rect = canvas.getBoundingClientRect();
         const x = e.clientX - rect.left;
         const y = e.clientY - rect.top;
+        const cp = computeControlPoint(dragNode, { x, y });
         const newNode = new Node(x, y);
         nodes.push(newNode);
-        dragNode.children.push(newNode);
+        dragNode.children.push({ node: newNode, cp });
         delete dragNode.temp;
         dragNode = null;
         dragging = false;
@@ -113,7 +138,7 @@ startBtn.addEventListener('click', () => {
         masterGain = audioCtx.createGain();
         masterGain.connect(audioCtx.destination);
         masterGain.gain.setValueAtTime(0.3, audioCtx.currentTime);
-        const rootNode = new Node(canvas.width / 2, canvas.height / 2);
+        const rootNode = new Node(canvas.width / 2, canvas.height / 2, { radius: 20 });
         nodes.push(rootNode);
         startBtn.style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- add pentatonic musical frequencies for each node
- allow connections to curve using quadratic beziers
- show temporary curve while dragging
- make the central knob larger
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ce436cb883259cef6708abfc71ab