### PR TITLE
Add noise color EQ with presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
 </head>
 <body>
 <button id="startBtn">Start Drone</button>
+<select id="colorSelect" style="display:none;">
+    <option value="white">White</option>
+    <option value="pink">Pink</option>
+    <option value="brown">Brown</option>
+    <option value="green">Green</option>
+    <option value="dark">Dark</option>
+</select>
 <canvas id="treeCanvas"></canvas>
 <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,15 @@ body {
     font-size: 1em;
 }
 
+#colorSelect {
+    position: absolute;
+    top: 10px;
+    left: 140px;
+    z-index: 10;
+    padding: 8px 12px;
+    font-size: 1em;
+}
+
 canvas {
     display: block;
     width: 100vw;


### PR DESCRIPTION
## Summary
- add noise color preset selector in the UI
- implement 5-band parametric EQ and noise generator
- connect EQ to oscillator tree and presets for dark/brown/pink/green/white
- style selector control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840cea08f9c8325b598785182bfe08f