### PR TITLE
Replace noise generator with EQ sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Experimental Organic Audio
 
 Start the drone and grow nodes from the central knob to shape a curved soundscape. Each node introduces a new oscillator tuned to a pentatonic scale so the result remains musical.
+
+After starting, use the "Dark", "Brown", "Pink", "Green" and "White" sliders to sculpt the overall tone. These sliders control a five‑band parametric EQ applied to every oscillator.

--- a/index.html
+++ b/index.html
@@ -8,13 +8,23 @@
 </head>
 <body>
 <button id="startBtn">Start Drone</button>
-<select id="colorSelect" style="display:none;">
-    <option value="white">White</option>
-    <option value="pink">Pink</option>
-    <option value="brown">Brown</option>
-    <option value="green">Green</option>
-    <option value="dark">Dark</option>
-</select>
+<div id="eqControls" style="display:none;">
+    <label>Dark
+        <input type="range" id="darkSlider" min="-12" max="12" value="0" step="0.1">
+    </label>
+    <label>Brown
+        <input type="range" id="brownSlider" min="-10" max="10" value="0" step="0.1">
+    </label>
+    <label>Pink
+        <input type="range" id="pinkSlider" min="-8" max="8" value="0" step="0.1">
+    </label>
+    <label>Green
+        <input type="range" id="greenSlider" min="-6" max="6" value="0" step="0.1">
+    </label>
+    <label>White
+        <input type="range" id="whiteSlider" min="-8" max="8" value="0" step="0.1">
+    </label>
+</div>
 <canvas id="treeCanvas"></canvas>
 <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -15,13 +15,24 @@ body {
     font-size: 1em;
 }
 
-#colorSelect {
+#eqControls {
     position: absolute;
     top: 10px;
     left: 140px;
     z-index: 10;
-    padding: 8px 12px;
-    font-size: 1em;
+    display: flex;
+    gap: 10px;
+}
+
+#eqControls label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.8em;
+    align-items: center;
+}
+
+#eqControls input[type="range"] {
+    width: 80px;
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- remove noise oscillator and presets
- add five EQ sliders controlling a parametric equaliser
- hook every oscillator to the EQ chain
- update styles and README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840d0f37dc483258f8feae9fce43938